### PR TITLE
fix GAUGE metrics

### DIFF
--- a/src/server/start.rs
+++ b/src/server/start.rs
@@ -73,8 +73,8 @@ async fn get_metrics(
 
     let (encoder, mut buffer) = metrics.get_encoder_and_buffer()?;
     let info_url_metric = format!("# HELP hyperliquid_info_url The Hyperliquid Info URL being used\n# TYPE hyperliquid_info_url gauge\nhyperliquid_info_url{{url=\"{}\"}} 1", info_url.to_string()).into_bytes();
-    let rpc_url_metric = format!("\n# HELP hyperliquid_rpc_url The Hyperliquid RPC URL being used\n# TYPE hyperliquid_rpc_url gauge\nhyperliquid_rpc_url '{}'\n", rpc_url).as_bytes().to_vec();
-
+    let rpc_url_metric = format!("\n# HELP hyperliquid_rpc_url The Hyperliquid RPC URL being used\n# TYPE hyperliquid_rpc_url gauge\nhyperliquid_rpc_url{{url=\"{}\"}} 1\n",rpc_url).into_bytes();
+    
     buffer.extend(&info_url_metric);
     buffer.extend(&rpc_url_metric);
 

--- a/src/server/start.rs
+++ b/src/server/start.rs
@@ -72,7 +72,7 @@ async fn get_metrics(
     metrics.update_for_rpc(&rpc_client.into_inner()).await?;
 
     let (encoder, mut buffer) = metrics.get_encoder_and_buffer()?;
-    let info_url_metric = format!("# HELP hyperliquid_info_url The Hyperliquid Info URL being used\n# TYPE hyperliquid_info_url gauge\nhyperliquid_info_url '{}'", info_url.to_string()).as_bytes().to_vec();
+    let info_url_metric = format!("# HELP hyperliquid_info_url The Hyperliquid Info URL being used\n# TYPE hyperliquid_info_url gauge\nhyperliquid_info_url{{url=\"{}\"}} 1", info_url.to_string()).into_bytes();
     let rpc_url_metric = format!("\n# HELP hyperliquid_rpc_url The Hyperliquid RPC URL being used\n# TYPE hyperliquid_rpc_url gauge\nhyperliquid_rpc_url '{}'\n", rpc_url).as_bytes().to_vec();
 
     buffer.extend(&info_url_metric);


### PR DESCRIPTION
I had issues scraping the metrics endpoint using grafana alloy

![Screenshot From 2024-12-20 14-29-54](https://github.com/user-attachments/assets/dfe852e7-d877-4ebe-b660-16c4f0a0a448)
![Screenshot From 2024-12-20 14-44-15](https://github.com/user-attachments/assets/d1427793-afc8-4333-ab29-a560e2956fd8)


According to prometheus documentation, GAUGE metrics should be numerical values :
https://prometheus.io/docs/concepts/metric_types/#gauge

With those changes I'm now able to scrape the endpoint without errors.

Would you accept those changes ?
